### PR TITLE
If the user starts an editor session on a directory, or on an

### DIFF
--- a/lua/lir/actions.lua
+++ b/lua/lir/actions.lua
@@ -92,7 +92,9 @@ function actions.quit()
   if vim.w.lir_is_float then
     a.nvim_win_close(0, true)
   else
-    vim.cmd('edit ' .. vim.w.lir_file_quit_on_edit)
+    if vim.w.lir_file_quit_on_edit ~= nil then
+      vim.cmd('edit ' .. vim.w.lir_file_quit_on_edit)
+    end
   end
 end
 


### PR DESCRIPTION
unnamed buffer, then swiches to lir, the quit action will
do nothing since there is nothing to go back to.