### PR TITLE
feat: float.win_opts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,24 +52,29 @@ require'lir'.setup {
     ['P'] = clipboard_actions.paste,
   },
   float = {
-    -- If you want to configure the height and width of the window individually,
-    -- pass in a table like so: { width = 0.5, height = 0.8 }
-    size_percentage = 0.5,
     winblend = 15,
-    border = true,
-    borderchars = {"╔" , "═" , "╗" , "║" , "╝" , "═" , "╚", "║"},
 
-    -- -- If you want to use `shadow`, set `shadow` to `true`.
-    -- -- Also, if you set shadow to true, the value of `borderchars` will be ignored.
-    -- shadow = false,
+    make_win_config = function()
+      local default_config = f_helper.make_default_win_config({
+       -- If you want to configure the height and width of the window individually,
+       -- pass in a table like so: { width = 0.5, height = 0.8 }
+        size_percentage = { width = 0.5, height = 0.5 },
+      })
 
-    -- -- You can customize the config passed to nvim_open_win().
-    -- -- see :h nvim_open_win()
-    -- make_win_config = function(default_config)
-    --   return vim.tbl_extend(default_config, {
-    --     row = 5,
-    --   })
-    -- end,
+      -- You can customize the config passed to nvim_open_win.
+      return vim.tbl_extend("force", default_config, {
+        border = f_helper.make_border_opts({
+          "+",
+          "─",
+          "+",
+          "│",
+          "+",
+          "─",
+          "+",
+          "│",
+        }, "LirFloatBorder"),
+      })
+    end,
   },
   hide_cursor = true,
 }

--- a/README.md
+++ b/README.md
@@ -57,11 +57,16 @@ require'lir'.setup {
     -- -- You can define a function that returns a table to be passed as the third
     -- -- argument of nvim_open_win().
     -- win_opts = function()
+    --   local width = math.floor(vim.o.columns * 0.8)
+    --   local height = math.floor(vim.o.lines * 0.8)
     --   return {
-    --     row = 1,
-    --     border = require'lir.float.helper'.make_border_opts({
+    --     border = require("lir.float.helper").make_border_opts({
     --       "+", "─", "+", "│", "+", "─", "+", "│",
     --     }, "Normal"),
+    --     width = width,
+    --     height = height,
+    --     row = 1,
+    --     col = math.floor((vim.o.columns - width) / 2),
     --   }
     -- end,
   },

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ require'lir'.setup {
     -- -- If you want to use `shadow`, set `shadow` to `true`.
     -- -- Also, if you set shadow to true, the value of `borderchars` will be ignored.
     -- shadow = false,
+
+    -- -- You can customize the config passed to nvim_open_win().
+    -- -- see :h nvim_open_win()
+    -- make_win_config = function(default_config)
+    --   return vim.tbl_extend(default_config, {
+    --     row = 5,
+    --   })
+    -- end,
   },
   hide_cursor = true,
 }

--- a/README.md
+++ b/README.md
@@ -52,29 +52,18 @@ require'lir'.setup {
     ['P'] = clipboard_actions.paste,
   },
   float = {
-    winblend = 15,
+    winblend = 0,
 
-    make_win_config = function()
-      local default_config = f_helper.make_default_win_config({
-       -- If you want to configure the height and width of the window individually,
-       -- pass in a table like so: { width = 0.5, height = 0.8 }
-        size_percentage = { width = 0.5, height = 0.5 },
-      })
-
-      -- You can customize the config passed to nvim_open_win.
-      return vim.tbl_extend("force", default_config, {
-        border = f_helper.make_border_opts({
-          "+",
-          "─",
-          "+",
-          "│",
-          "+",
-          "─",
-          "+",
-          "│",
-        }, "LirFloatBorder"),
-      })
-    end,
+    -- -- You can define a function that returns a table to be passed as the third
+    -- -- argument of nvim_open_win().
+    -- win_opts = function()
+    --   return {
+    --     row = 1,
+    --     border = require'lir.float.helper'.make_border_opts({
+    --       "+", "─", "+", "│", "+", "─", "+", "│",
+    --     }, "Normal"),
+    --   }
+    -- end,
   },
   hide_cursor = true,
 }
@@ -131,7 +120,6 @@ Change highlights groups.
 
 ```viml
 hi LirFloatNormal guibg=#32302f
-hi LirFloatBorder guifg=#7c6f64
 hi LirDir guifg=#7ebae4
 hi LirSymLink guifg=#7c6f64
 hi LirEmptyDirText guifg=#7c6f64

--- a/doc/lir.jax
+++ b/doc/lir.jax
@@ -34,6 +34,26 @@ lir.float.toggle([{dir}])                                 *lir.float.toggle()*
 
     `dir` が nil の場合、`vim.fn.expand('%:p:h')` が使われます。
 
+                                         *lir.float.helper.make_border_opts()*
+lir.float.helper.make_border_opts({borderchars}, {highlight})
+    |nvim_open_win()| の第3引数の config に渡す `border` の値を生成します。
+>
+    local border = require("lir.float.helper").make_border_opts({
+      "+", "─", "+", "│", "+", "─", "+", "│",
+    }, "Normal")
+
+    -- 以下の値が返されます。
+    {
+      { "+", "Normal" },
+      { "─", "Normal" },
+      { "+", "Normal" },
+      { "│", "Normal" },
+      { "+", "Normal" },
+      { "─", "Normal" },
+      { "+", "Normal" },
+      { "│", "Normal" },
+    }
+<
 
 ==============================================================================
 CONTEXT                                                          *lir-context*
@@ -135,11 +155,8 @@ SETTINGS                                                        *lir-settings*
       devicons_enable = false,
       mappings = {},
       float = {
-        size_percentage = 0.5,
         winblend = 15,
-        border = false,
-        borderchars = {"╔" , "═" , "╗" , "║" , "╝" , "═" , "╚", "║"},
-        shadow = false,
+        win_opts = nil
       },
       hide_cursor = false
     }
@@ -155,26 +172,29 @@ mappings                                               *lir-settings-mappings*
     table を指定する。
     自分で定義した関数を使用することもできます。
 
-float.size_percentage                     *lir-settings-float.size_percentage*
-    floating window で表示するウィンドウサイズの割合
+hide_cursor                                         *lir-settings-hide_cursor*
+    カーソルを非表示にするか
+    カーソルを表示する場合、先頭に空白が入る
 
 float.winblend                                   *lir-settings-float.winblend*
     floating window で表示するウィンドウの透過度合い
 
-float.border                                       *lir-settings-float.border*
-    ボーダーを表示するか
+float.win_opts                                   *lir-settings-float.win_opts*
+    |nvim_open_win()|の第3引数に渡すテーブルを返す関数を指定します。
+    以下のデフォルトの設定を上書きしたいときに使用します。
+    詳しくは設定例を見てください。
 
-float.borderchars                             *lir-settings-float.borderchars*
-    ボーダーの文字
-    左上から時計回りに指定する
-
-float.shadow                                       *lir-settings-float.shadow*
-    |nvim_open_win()| の shadow を使用するか
-    このオプションが `true` の場合、`float.borderchars` の値は無視されます。
-
-hide_cursor                                         *lir-settings-hide_cursor*
-    カーソルを非表示にするか
-    カーソルを表示する場合、先頭に空白が入る
+    デフォルト値: >
+      {
+        relative = "editor",
+        row = math.floor((vim.o.lines - (vim.o.lines * 0.5)) / 2) - 1,
+        col = math.floor((vim.o.lines - (vim.o.columns * 0.5)) / 2),
+        width = math.floor(vim.o.columns * 0.5),
+        height = math.floor(vim.o.lines * 0.5),
+        style = "minimal",
+        border = "bouble",
+      }
+<
 
 
 設定例: >
@@ -211,14 +231,23 @@ hide_cursor                                         *lir-settings-hide_cursor*
         ['P'] = clipboard_actions.paste,
       },
       float = {
-        size_percentage = 0.5,
         winblend = 15,
-        border = true,
-        borderchars = {"╔" , "═" , "╗" , "║" , "╝" , "═" , "╚", "║"},
 
-        -- -- If you want to use `shadow`, set `shadow` to `true`.
-        -- -- Also, if you set shadow to true, the value of `borderchars` will be ignored.
-        -- shadow = false,
+        -- You can define a function that returns a table to be passed as the third
+        -- argument of nvim_open_win().
+        win_opts = function()
+          local width = math.floor(vim.o.columns * 0.6)
+          local height = math.floor(vim.o.lines * 0.8)
+          return {
+            border = require("lir.float.helper").make_border_opts({
+              "+", "─", "+", "│", "+", "─", "+", "│",
+            }, "Normal"),
+            width = width,
+            height = height,
+            row = 10,
+            col = math.floor((vim.o.columns - width) / 2),
+          }
+        end,
       }
     }
 
@@ -255,13 +284,6 @@ LirFloatNormal                                                *LirFloatNormal*
     デフォルト: `highlight def link LirFloatNormal Normal``
 
     floating window のハイライト。
-
-
-LirFloatBorder                                                *LirFloatBorder*
-
-  デフォルト: `highlight def link LirFloatBorder LirFloatNormal`
-
-   floating window の枠線のハイライト。
 
 
 LirDir                                                                *LirDir*
@@ -449,6 +471,33 @@ A: おそらく、Neovim 本体の問題です。(https://github.com/neovim/neov
         ["`"] = function()
           vim.cmd("edit /")
           vim.cmd('duautocmd BufEnter')
+        end,
+      }
+    }
+<
+
+Q: floating window のサイズを割合で設定し、borderの設定をするにはどうすれば
+いいですか？
+
+A: |lir.setup()| の `float.win_opts` で設定可能です。
+    例) 横幅は60%、高さは80%、中央に配置。
+        border の線を設定し、ハイライトを Normal に設定
+>
+    require'lir'.setup {
+      -- ...
+      float = {
+        win_opts = function()
+          local width = math.floor(vim.o.columns * 0.6)
+          local height = math.floor(vim.o.lines * 0.8)
+          return {
+            border = require("lir.float.helper").make_border_opts({
+              "+", "─", "+", "│", "+", "─", "+", "│",
+            }, "Normal"),
+            width = width,
+            height = height,
+            row = math.floor((vim.o.columns - width) / 2) - 1,
+            col = math.floor((vim.o.columns - width) / 2),
+          }
         end,
       }
     }

--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -34,6 +34,28 @@ lir.float.toggle([{dir}])                                 *lir.float.toggle()*
 
     If `dir` is nil, then `vim.fn.expand('%:p:h')` is used.
 
+                                         *lir.float.helper.make_border_opts()*
+lir.float.helper.make_border_opts({borderchars}, {highlight})
+    Generate the value of `border` to be passed to config as the third
+    argument of |nvim_open_win()|.
+>
+    local border = require("lir.float.helper").make_border_opts({
+      "+", "─", "+", "│", "+", "─", "+", "│",
+    }, "Normal")
+
+    -- The following values are returned.
+    {
+      { "+", "Normal" },
+      { "─", "Normal" },
+      { "+", "Normal" },
+      { "│", "Normal" },
+      { "+", "Normal" },
+      { "─", "Normal" },
+      { "+", "Normal" },
+      { "│", "Normal" },
+    }
+<
+
 
 ==============================================================================
 CONTEXT                                                          *lir-context*
@@ -135,11 +157,8 @@ default value: >
       devicons_enable = false,
       mappings = {},
       float = {
-        size_percentage = 0.5,
         winblend = 15,
-        border = false,
-        borderchars = {"╔" , "═" , "╗" , "║" , "╝" , "═" , "╚", "║"},
-        shadow = false,
+        win_opts = nil
       },
       hide_cursor = false
     }
@@ -159,24 +178,31 @@ float.size_percentage                     *lir-settings-float.size_percentage*
     Percentage of the window size to be displayed in the floating window.
     You can either specify a `number` or a `table` with width and height keys.
 
-float.winblend                                   *lir-settings-float.winblend*
-    The degree of transparency of the window displayed by the floating
-    window.
-
-float.border                                       *lir-settings-float.border*
-    Show a border around the floating window?
-
-float.borderchars                             *lir-settings-float.borderchars*
-    A list of characters to be used for the border.
-
-float.shadow                                       *lir-settings-float.shadow*
-    Use `shadow` for |nvim_open_win()|.
-    If this option is `true`, the value of |float.borderchars| will be ignored.
-
 hide_cursor                                         *lir-settings-hide_cursor*
     Hide the cursor in lir?
     If the cursor is shown, it will be prefixed with a space.
 
+float.winblend                                   *lir-settings-float.winblend*
+    The degree of transparency of the window displayed by the floating
+    window.
+
+float.win_opts                                   *lir-settings-float.win_opts*
+    Specifies the function that returns the table to be passed as the
+    third argument of |nvim_open_win()|.
+    Use this when you want to override the default configs below.
+    See the configuration example for details.
+
+    Default config: >
+      {
+        relative = "editor",
+        row = math.floor((vim.o.lines - (vim.o.lines * 0.5)) / 2) - 1,
+        col = math.floor((vim.o.lines - (vim.o.columns * 0.5)) / 2),
+        width = math.floor(vim.o.columns * 0.5),
+        height = math.floor(vim.o.lines * 0.5),
+        style = "minimal",
+        border = "bouble",
+      }
+<
 
 Example: >
 
@@ -212,14 +238,23 @@ Example: >
         ['P'] = clipboard_actions.paste,
       },
       float = {
-        size_percentage = 0.5,
         winblend = 15,
-        border = true,
-        borderchars = {"╔" , "═" , "╗" , "║" , "╝" , "═" , "╚", "║"},
 
-        -- -- If you want to use `shadow`, set `shadow` to `true`.
-        -- -- Also, if you set shadow to true, the value of `borderchars` will be ignored.
-        -- shadow = false,
+        -- You can define a function that returns a table to be passed as the third
+        -- argument of nvim_open_win().
+        win_opts = function()
+          local width = math.floor(vim.o.columns * 0.6)
+          local height = math.floor(vim.o.lines * 0.8)
+          return {
+            border = require("lir.float.helper").make_border_opts({
+              "+", "─", "+", "│", "+", "─", "+", "│",
+            }, "Normal"),
+            width = width,
+            height = height,
+            row = 10,
+            col = math.floor((vim.o.columns - width) / 2),
+          }
+        end,
       }
     }
 
@@ -255,13 +290,6 @@ LirFloatNormal                                                *LirFloatNormal*
     Default: `highlight def link LirFloatNormal Normal``
 
     The highlight for float window.
-
-
-LirFloatBorder                                                *LirFloatBorder*
-
-    Default: `highlight def link LirFloatBorder LirFloatNormal`
-
-    The highlight for float window border.
 
 
 LirDir                                                                *LirDir*
@@ -449,6 +477,34 @@ So, do the following.
         ["`"] = function()
           vim.cmd("edit /")
           vim.cmd('duautocmd BufEnter')
+        end,
+      }
+    }
+<
+
+Q: How do I set the size of the floating window as a percentage and set the
+border?
+
+A: It can be set by `float.win_opts` in |lir.setup()|.
+    Example:
+        Width is 60%, height is 80%, centered.
+        Set the border line and set the highlight to Normal.
+>
+    require'lir'.setup {
+      -- ...
+      float = {
+        win_opts = function()
+          local width = math.floor(vim.o.columns * 0.6)
+          local height = math.floor(vim.o.lines * 0.8)
+          return {
+            border = require("lir.float.helper").make_border_opts({
+              "+", "─", "+", "│", "+", "─", "+", "│",
+            }, "Normal"),
+            width = width,
+            height = height,
+            row = math.floor((vim.o.columns - width) / 2) - 1,
+            col = math.floor((vim.o.columns - width) / 2),
+          }
         end,
       }
     }

--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -240,7 +240,7 @@ function lir.init()
   a.nvim_buf_set_option(0, "filetype", "lir")
 end
 
-function is_use_removed_config(prefs)
+local function is_use_removed_config(prefs)
   local float = prefs.float
   if vim.tbl_isempty(float) then
     return false
@@ -259,8 +259,12 @@ end
 ---@param prefs lir.config.values
 function lir.setup(prefs)
   if is_use_removed_config(prefs) then
+    -- stylua: ignore
     local msg =
-      string.format([[[lir.nvim] You are using a removed setting value. Please use float.win_opts. (see :h lir-settings-float.win_opts)]])
+      string.format(
+        '[lir.nvim] You are using a removed setting value. Please use float.win_opts.' ..
+        '(see :h lir-settings-float.win_opts)'
+      )
     a.nvim_echo({ { msg, "WarningMsg" } }, true, {})
   end
 

--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -45,7 +45,13 @@ local function readdir(path)
 
     if config.values.devicons_enable then
       local icon, highlight_name = devicons.get_devicons(name, is_dir)
-      file.display = string.format("%s%s %s%s", prefix, icon, name, (is_dir and "/" or ""))
+      file.display = string.format(
+        "%s%s %s%s",
+        prefix,
+        icon,
+        name,
+        (is_dir and "/" or "")
+      )
       file.devicons = { icon = icon, highlight_name = highlight_name }
     else
       file.display = prefix .. name .. (is_dir and "/" or "")
@@ -162,7 +168,8 @@ end
 ---@param devicon_enable boolean
 local function set_nocontent_text(devicon_enable)
   -- From vim-clap
-  local text = string.format(" %s Directory is empty", (devicon_enable and "" or " "))
+  local text =
+    string.format(" %s Directory is empty", (devicon_enable and "" or " "))
   a.nvim_buf_set_virtual_text(0, -1, 0, { { text, "LirEmptyDirText" } }, {})
 end
 
@@ -233,8 +240,30 @@ function lir.init()
   a.nvim_buf_set_option(0, "filetype", "lir")
 end
 
+function is_use_removed_config(prefs)
+  local float = prefs.float
+  if vim.tbl_isempty(float) then
+    return false
+  end
+
+  local deprecated_opts = { "size_percentage", "border", "borderchars", "shadow" }
+  for _, v in ipairs(deprecated_opts) do
+    if vim.tbl_contains(vim.tbl_keys(float), v) then
+      return true
+    end
+  end
+
+  return false
+end
+
 ---@param prefs lir.config.values
 function lir.setup(prefs)
+  if is_use_removed_config(prefs) then
+    local msg =
+      string.format([[[lir.nvim] You are using a removed setting value. Please use float.win_opts. (see :h lir-settings-float.win_opts)]])
+    a.nvim_echo({ { msg, "WarningMsg" } }, true, {})
+  end
+
   -- Set preferences
   config.set_default_values(prefs)
 

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -6,11 +6,7 @@ local defaults_values = {
   devicons_enable = false,
   mappings = {},
   float = {
-    size_percentage = { width = 0.5, height = 0.5 },
     winblend = 15,
-    border = false,
-    borderchars = { "╔", "═", "╗", "║", "╝", "═", "╚", "║" },
-    shadow = false,
   },
   hide_cursor = false,
 }

--- a/lua/lir/float/helper.lua
+++ b/lua/lir/float/helper.lua
@@ -1,0 +1,60 @@
+local F = require("plenary.functional")
+
+local M = {}
+
+local default_opts = {
+  size_percentage = { width = 0.5, height = 0.5 },
+  border = "none",
+}
+
+--- Return a table with highlighted borderchars.
+---   { {'=', highlight }, {'|', highlight}, ... }
+---@param borderchars table
+---@param highlight string
+---@return table
+M.make_border_opts = function(borderchars, highlight)
+  return vim.tbl_map(function(char)
+    return { char, highlight }
+  end, borderchars)
+end
+
+--- Return the default value of the option
+---@param opts table
+---@return table
+M.make_default_win_config = function(opts)
+  opts = F.if_nil(opts, default_opts, opts)
+
+  local width_percentage, height_percentage
+  if type(opts.size_percentage) == "number" then
+    width_percentage = opts.size_percentage
+    height_percentage = opts.size_percentage
+  elseif type(opts.size_percentage) == "table" then
+    width_percentage = opts.size_percentage.width
+    height_percentage = opts.size_percentage.height
+  else
+    error(string.format(
+      "'size_percentage' can be either number or table: %s",
+      vim.inspect(opts.size_percentage)
+    ))
+  end
+
+  local width = math.floor(vim.o.columns * width_percentage)
+  local height = math.floor(vim.o.lines * height_percentage)
+
+  local top = math.floor(((vim.o.lines - height) / 2) - 1)
+  local left = math.floor((vim.o.columns - width) / 2)
+
+  local result = {
+    relative = "editor",
+    row = top,
+    col = left,
+    width = width,
+    height = height,
+    style = "minimal",
+    border = opts.border,
+  }
+
+  return result
+end
+
+return M

--- a/lua/lir/float/helper.lua
+++ b/lua/lir/float/helper.lua
@@ -1,11 +1,4 @@
-local F = require("plenary.functional")
-
 local M = {}
-
-local default_opts = {
-  size_percentage = { width = 0.5, height = 0.5 },
-  border = "none",
-}
 
 --- Return a table with highlighted borderchars.
 ---   { {'=', highlight }, {'|', highlight}, ... }
@@ -16,45 +9,6 @@ M.make_border_opts = function(borderchars, highlight)
   return vim.tbl_map(function(char)
     return { char, highlight }
   end, borderchars)
-end
-
---- Return the default value of the option
----@param opts table
----@return table
-M.make_default_win_config = function(opts)
-  opts = F.if_nil(opts, default_opts, opts)
-
-  local width_percentage, height_percentage
-  if type(opts.size_percentage) == "number" then
-    width_percentage = opts.size_percentage
-    height_percentage = opts.size_percentage
-  elseif type(opts.size_percentage) == "table" then
-    width_percentage = opts.size_percentage.width
-    height_percentage = opts.size_percentage.height
-  else
-    error(string.format(
-      "'size_percentage' can be either number or table: %s",
-      vim.inspect(opts.size_percentage)
-    ))
-  end
-
-  local width = math.floor(vim.o.columns * width_percentage)
-  local height = math.floor(vim.o.lines * height_percentage)
-
-  local top = math.floor(((vim.o.lines - height) / 2) - 1)
-  local left = math.floor((vim.o.columns - width) / 2)
-
-  local result = {
-    relative = "editor",
-    row = top,
-    col = left,
-    width = width,
-    height = height,
-    style = "minimal",
-    border = opts.border,
-  }
-
-  return result
 end
 
 return M

--- a/lua/lir/float/init.lua
+++ b/lua/lir/float/init.lua
@@ -1,12 +1,40 @@
 local actions = require("lir.actions")
 local lvim = require("lir.vim")
 local config = require("lir.config")
-local helper = require("lir.float.helper")
+local F = require("plenary.functional")
 
 local a = vim.api
 
 ---@class lir_float
 local float = {}
+
+local default_win_opts = {
+  width = 0.5,
+  height = 0.5,
+  border = "double",
+}
+
+--- Return the default value of the option
+---@return table
+local make_default_win_config = function()
+  local width = math.floor(vim.o.columns * default_win_opts.width)
+  local height = math.floor(vim.o.lines * default_win_opts.height)
+
+  local top = math.floor(((vim.o.lines - height) / 2) - 1)
+  local left = math.floor((vim.o.columns - width) / 2)
+
+  local result = {
+    relative = "editor",
+    row = top,
+    col = left,
+    width = width,
+    height = height,
+    style = "minimal",
+    border = default_win_opts.border,
+  }
+
+  return result
+end
 
 --- 中央配置のウィンドウを開く
 ---@return number win_id
@@ -67,13 +95,12 @@ function float.init(dir_path)
     file = vim.fn.expand("%:p")
   end
 
-  local win_config
-  if type(config.values.float.make_win_config) == "function" then
-    win_config = config.values.float.make_win_config()
-  else
-    win_config = helper.make_default_win_config()
+  local user_win_opts = {}
+  if type(config.values.float.win_opts) == "function" then
+    user_win_opts = config.values.float.win_opts()
   end
 
+  win_config = vim.tbl_extend("force", make_default_win_config(), user_win_opts)
   local win_id = open_win(win_config, config.values.float.winblend)
 
   vim.t.lir_float_winid = win_id

--- a/lua/lir/float/init.lua
+++ b/lua/lir/float/init.lua
@@ -1,7 +1,6 @@
 local actions = require("lir.actions")
 local lvim = require("lir.vim")
 local config = require("lir.config")
-local F = require("plenary.functional")
 
 local a = vim.api
 
@@ -100,7 +99,7 @@ function float.init(dir_path)
     user_win_opts = config.values.float.win_opts()
   end
 
-  win_config = vim.tbl_extend("force", make_default_win_config(), user_win_opts)
+  local win_config = vim.tbl_extend("force", make_default_win_config(), user_win_opts)
   local win_id = open_win(win_config, config.values.float.winblend)
 
   vim.t.lir_float_winid = win_id

--- a/lua/lir/float/init.lua
+++ b/lua/lir/float/init.lua
@@ -69,7 +69,7 @@ function float.init(dir_path)
 
   local win_config
   if type(config.values.float.make_win_config) == "function" then
-    win_config = config.values.float.make_win_config(win_config)
+    win_config = config.values.float.make_win_config()
   else
     win_config = helper.make_default_win_config()
   end

--- a/plugin/lir.vim
+++ b/plugin/lir.vim
@@ -24,7 +24,6 @@ augroup END
 
 
 highlight def link LirFloatNormal  Normal
-highlight def link LirFloatBorder  LirFloatNormal
 highlight def link LirDir          PreProc
 highlight def link LirSymLink      PreProc
 highlight def link LirEmptyDirText BlueSign


### PR DESCRIPTION
The user can customize the config passed to `nvim_open_win()` by using `float.win_opts`.

refer https://github.com/tamago324/lir.nvim/issues/23#issuecomment-868740721


Example:

```lua
local actions = require'lir.actions'
local mark_actions = require 'lir.mark.actions'
local clipboard_actions = require'lir.clipboard.actions'
local f_helper = require("lir.float.helper")

require'lir'.setup {
  -- ...
  float = {
    winblend = 0,

    -- You can define a function that returns a table to be passed as the third
    -- argument of nvim_open_win().
    win_opts = function()
      local width = math.floor(vim.o.columns * 0.8)
      local height = math.floor(vim.o.lines * 0.8)

      return {
        border = require("lir.float.helper").make_border_opts({
          "+", "─", "+", "│", "+", "─", "+", "│",
        }, "Normal"),
        width = width,
        height = height,
        row = 1,
        col = math.floor((vim.o.columns - width) / 2),
      }
    end,
}
```


### A helper functions are provided:

**`lir.float.helper.make_border_opts(borderchars, highlight)`**
Returns a table that can be passed to config.border in nvim_open_win() by passing the border string and highlight name.
