### PR TITLE
fix: empty table if nil

### DIFF
--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -241,7 +241,7 @@ function lir.init()
 end
 
 local function is_use_removed_config(prefs)
-  local float = prefs.float
+  local float = prefs.float or {}
   if vim.tbl_isempty(float) then
     return false
   end


### PR DESCRIPTION
I got an error after the newest update. Found it was because prefs.float was nil. I changed it to be an empty table if someone has not configured floats in the setup