### PR TITLE
feat: `actions.wipeout` to delete buffer and file simultaneously

### DIFF
--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -200,7 +200,7 @@ float.win_opts                                   *lir-settings-float.win_opts*
         width = math.floor(vim.o.columns * 0.5),
         height = math.floor(vim.o.lines * 0.5),
         style = "minimal",
-        border = "bouble",
+        border = "double",
       }
 <
 
@@ -347,8 +347,15 @@ mkdir()                                                  *lir.actions.mkdir()*
 rename()                                                *lir.actions.rename()*
     Rename a file.
 
-delete()                                                *lir.actions.delete()*
+delete([{force}])                                       *lir.actions.delete()*
     Delete a file.
+    To delete the file and buffer simultaneously, see |lir.actions.wipeout()|
+
+        Parameters: ~
+            {force} (boolean) If `true`, do not ask for confirmation.
+
+wipeout()                                              *lir.actions.wipeout()*
+    Delete a file and the respective buffer simultaneously.
 
 newfile()                                              *lir.actions.newfile()*
     Create a new file.

--- a/lua/lir/actions.lua
+++ b/lua/lir/actions.lua
@@ -168,11 +168,11 @@ function actions.rename()
 end
 
 --- delete
-function actions.delete()
+function actions.delete(force)
   local ctx = get_context()
   local name = ctx:current_value()
 
-  if vim.fn.confirm("Delete?: " .. name, "&Yes\n&No", 1) ~= 1 then
+  if not force and vim.fn.confirm("Delete?: " .. name, "&Yes\n&No", 1) ~= 1 then
     -- Esc は 0 を返す
     return
   end
@@ -188,6 +188,24 @@ function actions.delete()
   end
 
   actions.reload()
+end
+
+--- wipeout
+function actions.wipeout()
+  local ctx = get_context()
+  if not ctx:is_dir_current() then
+    local name = ctx:current_value()
+    local bufnr = vim.fn.bufnr(name)
+    if vim.fn.confirm("Delete?: " .. name, "&Yes\n&No", 1) ~= 1 then
+      return
+    end
+    if bufnr ~= -1 then
+      a.nvim_buf_delete(bufnr, {force = true})
+    end
+    actions.delete(true)
+  else
+    actions.delete()
+  end
 end
 
 --- newfile

--- a/lua/lir/actions.lua
+++ b/lua/lir/actions.lua
@@ -194,13 +194,13 @@ end
 function actions.wipeout()
   local ctx = get_context()
   if not ctx:is_dir_current() then
-    local name = ctx:current_value()
+    local name = ctx:current().fullpath
     local bufnr = vim.fn.bufnr(name)
     if vim.fn.confirm("Delete?: " .. name, "&Yes\n&No", 1) ~= 1 then
       return
     end
     if bufnr ~= -1 then
-      a.nvim_buf_delete(bufnr, {force = true})
+      a.nvim_buf_delete(bufnr, { force = true })
     end
     actions.delete(true)
   else


### PR DESCRIPTION
If the file is loaded into a buffer, then the buffer and the file will be deleted simultaneously. This is similar to vim-eunuch's `:Delete` command.

I've added the `force` parameter to `actions.delete` to avoid asking for confirmation from the user twice. We want to confirm before deleting the buffer as well.

@tamago324 Can you test this out?

I've tested it with the following cases:
- Deleting a directory with confirmation prompt to 'Yes' and 'No'
- Deleting a file without loading it into a buffer with confirmation prompt to 'Yes' and 'No'
- Deleting a file after loading it into a buffer with confirmation prompt to 'Yes' and 'No'

Ref: #23 