### PR TITLE
feat: specifies the split direction of edit

### DIFF
--- a/doc/lir.jax
+++ b/doc/lir.jax
@@ -347,8 +347,14 @@ NOTE: see https://github.com/tamago324/lir.nvim/wiki/Custom-actions
 ------------------------------------------------------------------------------
 Lua module: lir.actions                                          *lir-actions*
 
-edit()                                                    *lir.actions.edit()*
+edit([{opts}])                                            *lir.actions.edit()*
     カーソル下のファイルを|:edit| を使って開く。
+
+        Parameters: ~
+            {opts} (table) 編集のコマンドの定義。 Keys: 
+                    • `modified_split_command` : ファイルが保存されていないと
+                      き、ファイルを開くときに使用するコマンド。
+                      (デフォルト: `'split'`)
 
 split()                                                  *lir.actions.split()*
     カーソル下のファイルを|:new| を使って開く。

--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -354,8 +354,15 @@ NOTE: see https://github.com/tamago324/lir.nvim/wiki/Custom-actions
 ------------------------------------------------------------------------------
 Lua module: lir.actions                                          *lir-actions*
 
-edit()                                                    *lir.actions.edit()*
+edit([{opts}])                                            *lir.actions.edit()*
     Use |:edit| to open the file under the cursor.
+
+        Parameters: ~
+            {opts} (table) Definition of editing commands. Keys: 
+                    • `modified_split_command` : Specifies the command to use
+                      when opening a file when the file has not been saved.
+                      (Default: `'split'`)
+
 
 split()                                                  *lir.actions.split()*
     Use |:new| to open the file under the cursor.

--- a/lua/lir/actions.lua
+++ b/lua/lir/actions.lua
@@ -44,7 +44,11 @@ end
 -----------------------------
 
 --- edit
-function actions.edit()
+---@param opts table
+function actions.edit(opts)
+  opts = opts or {}
+  local modified_split_command = vim.F.if_nil(opts.modified_split_command, 'split')
+
   local ctx = get_context()
   local dir, file = ctx.dir, ctx:current_value()
   if not file then
@@ -58,7 +62,8 @@ function actions.edit()
     actions.quit()
   end
 
-  local cmd = (vim.api.nvim_buf_get_option(0, "modified") and "split") or "edit"
+  print(modified_split_command)
+  local cmd = (vim.api.nvim_buf_get_option(0, "modified") and modified_split_command) or "edit"
 
   vim.cmd(string.format("%s %s %s", keepalt, cmd, vim.fn.fnameescape(dir .. file)))
   history.add(dir, file)


### PR DESCRIPTION
refer #46.

Can be specified by passing it to a function.

```lua
require("lir").setup({
  -- ...
  mappings = {
    ["S"] = function()
      actions.edit({ modified_split_command = 'vsplit' })
    end,
  }
}
```