### PR TITLE
fix: Don't resolve symlinks in init.

### DIFF
--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -173,7 +173,7 @@ end
 local lir = {}
 
 function lir.init()
-  local path = vim.fn.resolve(vim.fn.expand("%:p"))
+  local path = vim.fn.expand("%:p")
 
   if path == "" or not Path:new(path):is_dir() then
     return


### PR DESCRIPTION
Resolving symlinks when initializing the context makes it such that some actions that target the current dir has unexpected results when that dir is a symlink, as they will operate on the link target rather than the link location.

Take this example file structure:

```
.
├── lorem
│   └── ipsum
│       ├── foo
│       ├── bar
│       └── baz
└── dolor
    └── sit
        └── amet [ -> ./lorem/ipsum ]
            ├── foo
            ├── bar
            └── baz
```

If I navigate into `amet` in Lir, and then use the `up()` action, I end up in `lorem`. Here I would expect to end up in `sit`.

Another example, is the `cd()` action. If I use this action from `amet`, Lir will actually `cd` into `./lorem/ipsum`, instead of the expected `./dolor/sit/amet`.

This goes for all actions that use the `context.dir` field.

Is there any particular reason that I'm missing for as to why `resolve()` is used here?
