### PR TITLE
Fix logic for `ignore` files

### DIFF
--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -215,9 +215,7 @@ function lir.init()
     end
     files = vim.tbl_filter(function(val)
       local f = "^" .. file .. ".-$"
-      if string.match(val.value, f) then
-        return string.match(val.value, f) ~= nil
-      end
+      return string.match(val.value, f) == nil
     end, files)
   end
 


### PR DESCRIPTION
#72 introduced an `ignore` table where desired ignored files can be listed to not appear in lir's results. However, there is a bug – the logic for this table is inverted! This diff fixes this bug so that ignore files are ignored and all other files are listed correctly.