### PR TITLE
Add on option to keep lir open after opening a file in a split or tab

### DIFF
--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -416,14 +416,26 @@ edit([{opts}])                                            *lir.actions.edit()*
                       (Default: `'split'`)
 
 
-split()                                                  *lir.actions.split()*
+split([{quit_lir}])                                      *lir.actions.split()*
     Use |:new| to open the file under the cursor.
 
-vsplit()                                                *lir.actions.vsplit()*
+        Parameters:
+            {quit_lir} (boolean) Quit lir after opening the new file (default)
+                If false lir will remain open.
+
+vsplit([{quit_lir}])                                    *lir.actions.vsplit()*
     Use |:vnew| to open the file under the cursor.
 
-tabedit()                                              *lir.actions.tabedit()*
+        Parameters:
+            {quit_lir} (boolean) Quit lir after opening the new file (default)
+                If false lir will remain open.
+
+tabedit([{quit_lir}])                                  *lir.actions.tabedit()*
     Use |:tabedit| to open the file under the cursor.
+
+        Parameters:
+            {quit_lir} (boolean) Quit lir after opening the new file (default)
+                If false lir will remain open.
 
 up()                                                        *lir.actions.up()*
     Move to the parent directory.

--- a/lua/lir/actions.lua
+++ b/lua/lir/actions.lua
@@ -20,13 +20,16 @@ local actions = {}
 local get_context = lvim.get_context
 
 ---@param cmd string
-local function open(cmd)
+---@param quit_lir boolean | nil
+local function open(cmd, quit_lir)
   local ctx = get_context()
   if not ctx:current_value() then
     return
   end
   local filename = vim.fn.fnameescape(ctx.dir .. ctx:current_value())
-  actions.quit()
+  if quit_lir ~= false then
+    actions.quit()
+  end
   vim.cmd(cmd .. " " .. filename)
   history.add(ctx.dir, ctx:current_value())
 end
@@ -70,18 +73,21 @@ function actions.edit(opts)
 end
 
 --- split
-function actions.split()
-  open("new")
+---@param quit_lir boolean | nil
+function actions.split(quit_lir)
+  open("new", quit_lir)
 end
 
 --- vsplit
-function actions.vsplit()
-  open("vnew")
+---@param quit_lir boolean | nil
+function actions.vsplit(quit_lir)
+  open("vnew", quit_lir)
 end
 
 --- tabedit
-function actions.tabedit()
-  open("tabedit")
+---@param quit_lir boolean | nil
+function actions.tabedit(quit_lir)
+  open("tabedit", quit_lir)
 end
 
 --- up


### PR DESCRIPTION
This adds an optional `quit_lir` parameter to `split`, `vsplit` and `tabedit`. Default behavior remains unchanged, but passing `false` to those actions will prevent the `quit` action from being called after a new file is opened.

I updated the docs in `lir.txt`. Unfortunately my Japanese isn't good enough to update `lir.jax`.