### PR TITLE
feat: add config option to highlight dir with devicons active

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require'lir'.setup {
   ignore = {}, -- { ".DS_Store" "node_modules" } etc.
   devicons = {
     enable = false,
-    highlight_dirnames = false
+    highlight_dirname = false
   },
   mappings = {
     ['l']     = actions.edit,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ local clipboard_actions = require'lir.clipboard.actions'
 require'lir'.setup {
   show_hidden_files = false,
   ignore = {}, -- { ".DS_Store" "node_modules" } etc.
-  devicons_enable = true,
+  devicons = {
+    enable = false,
+    highlight_dirnames = false
+  },
   mappings = {
     ['l']     = actions.edit,
     ['<C-s>'] = actions.split,
@@ -74,7 +77,6 @@ require'lir'.setup {
     -- end,
   },
   hide_cursor = true,
-  highlight_dirnames_with_devicons = false,
   on_init = function()
     -- use visual mode
     vim.api.nvim_buf_set_keymap(

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A simple file explorer
 
 Note: lir.nvim does not define any default mappings, you need to configure them yourself by referring to [help](doc/lir.txt).
 
-
 ## Installation
 
 ```vim
@@ -14,7 +13,6 @@ Plug 'nvim-lua/plenary.nvim'
 " Optional
 Plug 'kyazdani42/nvim-web-devicons'
 ```
-
 
 ## Configuration
 
@@ -76,6 +74,7 @@ require'lir'.setup {
     -- end,
   },
   hide_cursor = true,
+  highlight_dirnames_with_devicons = false,
   on_init = function()
     -- use visual mode
     vim.api.nvim_buf_set_keymap(
@@ -124,19 +123,17 @@ or
 :lua require'lir.float'.init()
 ```
 
-
 ### Extensions
 
-* [tamago324/lir-mmv.nvim](https://github.com/tamago324/lir-mmv.nvim)
-* [tamago324/lir-bookmark.nvim](https://github.com/tamago324/lir-bookmark.nvim)
-* [tamago324/lir-git-status.nvim](https://github.com/tamago324/lir-git-status.nvim)
-
+- [tamago324/lir-mmv.nvim](https://github.com/tamago324/lir-mmv.nvim)
+- [tamago324/lir-bookmark.nvim](https://github.com/tamago324/lir-bookmark.nvim)
+- [tamago324/lir-git-status.nvim](https://github.com/tamago324/lir-git-status.nvim)
 
 ## Credit
 
-* [mattn/vim-molder](https://github.com/mattn/vim-molder)
-* [norcalli/nvim_utils](https://github.com/norcalli/nvim_utils)
-* [lambdalisue/fern.vim](https://github.com/lambdalisue/fern.vim)
+- [mattn/vim-molder](https://github.com/mattn/vim-molder)
+- [norcalli/nvim_utils](https://github.com/norcalli/nvim_utils)
+- [lambdalisue/fern.vim](https://github.com/lambdalisue/fern.vim)
 
 ## Screenshots
 

--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -178,7 +178,10 @@ default value: >
     {
       show_hidden_files = false,
       ignore = {},
-      devicons_enable = false,
+      devicons = {
+        enable = false,
+        highlight_dirnames = false
+      },
       hide_cursor = false
       mappings = {},
       float = {
@@ -199,8 +202,12 @@ show_hidden_files                             *lir-settings-show_hidden_files*
 ignore                                                   *lir-settings-ignore*
     List of files not to be displayed.
 
-devicons_enable                                 *lir-settings-devicons_enable*
+devicons.enable                                 *lir-settings-devicons.enable*
     Show devicons?
+
+devicons.highlight_dirnames                     *lir-settings-devicons.highlight_dirnames*
+    Highlight dirnames with devicons enabled?
+    Only has an effect when `devicons.enable = true`
 
 mappings                                               *lir-settings-mappings*
     Specify the table to be used for mapping.

--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -180,7 +180,7 @@ default value: >
       ignore = {},
       devicons = {
         enable = false,
-        highlight_dirnames = false
+        highlight_dirname = false
       },
       hide_cursor = false
       mappings = {},
@@ -205,7 +205,7 @@ ignore                                                   *lir-settings-ignore*
 devicons.enable                                 *lir-settings-devicons.enable*
     Show devicons?
 
-devicons.highlight_dirnames                     *lir-settings-devicons.highlight_dirnames*
+devicons.highlight_dirname                     *lir-settings-devicons.highlight_dirname*
     Highlight dirnames with devicons enabled?
     Only has an effect when `devicons.enable = true`
 

--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -46,7 +46,7 @@ local function readdir(path)
 
     local prefix = config.values.hide_cursor and "" or " "
 
-    if config.values.devicons_enable then
+    if config.values.devicons.enable then
       local icon, highlight_name = devicons.get_devicons(name, is_dir)
       file.display = string.format("%s%s %s%s", prefix, icon, name, (is_dir and "/" or ""))
       file.devicons = { icon = icon, highlight_name = highlight_name }
@@ -254,7 +254,7 @@ function lir.setup(prefs)
   config.set_default_values(prefs)
 
   -- devicons
-  if config.values.devicons_enable then
+  if config.values.devicons.enable then
     devicons.setup()
   end
 end

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -6,6 +6,7 @@ local defaults_values = {
   ignore = {},
   devicons_enable = false,
   hide_cursor = false,
+  highlight_dirnames_with_devicons = false,
   on_init = function() end,
   mappings = {},
   float = {
@@ -29,6 +30,7 @@ local config = {}
 ---@field ignore            table
 ---@field show_hidden_files boolean
 ---@field devicons_enable   boolean
+---@field highlight_dirnames_with_devicons   boolean
 ---@field on_init           function
 ---@field mappings          table
 ---@field float             lir.config.values.float

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -6,7 +6,7 @@ local defaults_values = {
   ignore = {},
   devicons = {
     enable = false,
-    highlight_dirnames = false
+    highlight_dirname = false
   },
   hide_cursor = false,
   on_init = function() end,
@@ -40,7 +40,7 @@ config.values = {}
 
 ---@class lir.config.values.devicons
 ---@field enable            boolean
----@field highlight_dirnames boolean
+---@field highlight_dirname boolean
 
 ---@class lir.config.values.float
 ---@field winblend        number

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -31,7 +31,7 @@ local config = {}
 ---@class lir.config.values
 ---@field ignore            table
 ---@field show_hidden_files boolean
----@field devicons          table
+---@field devicons          lir.config.values.devicons
 ---@field on_init           function
 ---@field mappings          table
 ---@field float             lir.config.values.float
@@ -64,6 +64,19 @@ function config.set_default_values(opts)
     config.values.float = defaults_values.float
   elseif vim.tbl_isempty(config.values.float.curdir_window) then
     config.values.float.curdir_window = defaults_values.float.curdir_window
+  end
+
+  if vim.tbl_isempty(config.values.devicons) then
+    config.values.devicons = defaults_values.devicons
+  end
+
+  if opts.devicons_enable then
+    config.values.devicons.enable = true
+    -- echo waring
+    vim.api.nvim_echo({ { '\n', 'Normal' } }, false, {})
+    vim.api.nvim_echo(
+      { { '[lir.nvim] `devicons_enable` is deprecated. Use `devicons.enable` instead. \n', 'WarningMsg' } },
+      false, {})
   end
 end
 

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -4,9 +4,11 @@
 local defaults_values = {
   show_hidden_files = false,
   ignore = {},
-  devicons_enable = false,
+  devicons = {
+    enable = false,
+    highlight_dirnames = false
+  },
   hide_cursor = false,
-  highlight_dirnames_with_devicons = false,
   on_init = function() end,
   mappings = {},
   float = {
@@ -29,13 +31,16 @@ local config = {}
 ---@class lir.config.values
 ---@field ignore            table
 ---@field show_hidden_files boolean
----@field devicons_enable   boolean
----@field highlight_dirnames_with_devicons   boolean
+---@field devicons          table
 ---@field on_init           function
 ---@field mappings          table
 ---@field float             lir.config.values.float
 ---@field hide_cursor       boolean
 config.values = {}
+
+---@class lir.config.values.devicons
+---@field enable            boolean
+---@field highlight_dirnames boolean
 
 ---@class lir.config.values.float
 ---@field winblend        number

--- a/lua/lir/devicons.lua
+++ b/lua/lir/devicons.lua
@@ -23,7 +23,7 @@ function devicons.setup()
   if not has_devicons then
     utils.error("[lir.nvim] Require nvim-web-devicons")
     -- XXX: Can I change the config here?
-    -- config.values.devicons_enable = false
+    -- config.values.devicons.enable = false
     return
   end
   local folder_icon, _ = Devicons.get_icon(FOLDER_ICON_NAME)

--- a/lua/lir/highlight.lua
+++ b/lua/lir/highlight.lua
@@ -17,10 +17,10 @@ local highlight = {}
 
 ---@param files lir_item[]
 function highlight.update_highlight(files)
-  if config.values.devicons_enable then
+  if config.values.devicons.enable then
     devicons.update_highlight(files)
   end
-  if not config.values.devicons_enable or config.values.highlight_dirnames_with_devicons then
+  if not config.values.devicons.enable or config.values.devicons.highlight_dirnames then
     a.nvim_buf_clear_namespace(0, ns, 0, -1)
     for i, file in ipairs(files) do
       if file.is_dir then

--- a/lua/lir/highlight.lua
+++ b/lua/lir/highlight.lua
@@ -20,7 +20,7 @@ function highlight.update_highlight(files)
   if config.values.devicons.enable then
     devicons.update_highlight(files)
   end
-  if not config.values.devicons.enable or config.values.devicons.highlight_dirnames then
+  if not config.values.devicons.enable or config.values.devicons.highlight_dirname then
     a.nvim_buf_clear_namespace(0, ns, 0, -1)
     for i, file in ipairs(files) do
       if file.is_dir then

--- a/lua/lir/highlight.lua
+++ b/lua/lir/highlight.lua
@@ -19,7 +19,8 @@ local highlight = {}
 function highlight.update_highlight(files)
   if config.values.devicons_enable then
     devicons.update_highlight(files)
-  else
+  end
+  if not config.values.devicons_enable or config.values.highlight_dirnames_with_devicons then
     a.nvim_buf_clear_namespace(0, ns, 0, -1)
     for i, file in ipairs(files) do
       if file.is_dir then


### PR DESCRIPTION
only makes a difference with devicons on.
highlight_dirnames_with_devicons = false:
![image](https://user-images.githubusercontent.com/65673442/211156955-229c0afc-a546-443f-bfa3-09c92aa70485.png)
highlight_dirnames_with_devicons = true:
![image](https://user-images.githubusercontent.com/65673442/211157044-14c0b612-1003-49bb-b99c-d475fd7a6bc4.png)
