### PR TITLE
fix: get_filters nil op

### DIFF
--- a/doc/lir.jax
+++ b/doc/lir.jax
@@ -192,7 +192,7 @@ SETTINGS                                                        *lir-settings*
         }
       },
       on_init = function() end,
-      get_filters = {}
+      get_filters = nil
     }
 <
 

--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -193,6 +193,7 @@ default value: >
         }
       },
       on_init = function() end,
+      get_filters = nil
     }
 <
 

--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -226,7 +226,10 @@ function lir.init()
 
   table.sort(files, sort)
 
-  files = do_filter(files)
+  local do_filter_status, filtered_files = pcall(do_filter, files)
+  if do_filter_status then
+    files = filtered_files
+  end
 
   context.files = files
   setlines(


### PR DESCRIPTION
## Description

If filters isn't a supplied a function for config's `get_filters`, `do_filters` tries to operate on the default nil

This commit
  * fixes with a pcall safety check on the operation
  * updates doc files (.jax, .txt) with default `nil` value (default set in `config.lua`)

## Issue Resolutions

- #82
