### PR TITLE
Add natural sort option

### DIFF
--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -67,6 +67,16 @@ local function sort(lhs, rhs)
   elseif not lhs.is_dir and rhs.is_dir then
     return false
   end
+
+  if config.values.natural_sort then
+    ---@see http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua
+    local function padnum(d)
+      return ("%012d"):format(d)
+    end
+
+    return tostring(lhs.value):gsub("%d+", padnum) < tostring(rhs.value):gsub("%d+", padnum)
+  end
+
   return lhs.value < rhs.value
 end
 

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -15,6 +15,7 @@ local defaults_values = {
       highlight_dirname = false,
     },
   },
+  natural_sort = false,
   get_filters = nil,
 }
 
@@ -30,9 +31,9 @@ local config = {}
 ---@field mappings          table
 ---@field float             lir.config.values.float
 ---@field hide_cursor       boolean
+---@field natural_sort      boolean
 ---@field get_filters fun(): lir.config.filter_func[]
 config.values = {}
-
 
 ---@class lir.config.values.devicons
 ---@field enable            boolean


### PR DESCRIPTION
First, thank you for the plugin. 

Recently I have been working on a lot of numeric directory names. But this plugin didn't have a way to use natural sort. So I have implemented a solution based on this [blog](http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua). 

In the thread the author mentioned there is also another [implementation](http://lua-users.org/lists/lua-l/2012-08/msg00246.html) but since the previous is simpler  and I don't know your copyright policy I used the above.

Let me know what you think.