### PR TITLE
add options for a custom header, disabling highlights and showing './' and '../'

### DIFF
--- a/doc/lir.txt
+++ b/doc/lir.txt
@@ -234,6 +234,15 @@ get_filters                                         *lir-settings-get_filters*
 
         `fun(files: lir_item[]): lir_item[]`
 
+header                                                      lir-settings-header
+    A (multiline) string that will be displayed at the top of a lir buffer.
+
+disable_highlight                                lir-settings-disable_highlight
+    Set to true to disable directory highlighting inside a lir buffer.
+
+show_navigation                                    lir-settings-show_navigation
+    Set to true to show '../' and './' in the file list.
+
 float.winblend                                   *lir-settings-float.winblend*
     The degree of transparency of the window displayed by the floating
     window.

--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -287,6 +287,13 @@ function lir.init()
     highlight.update_highlight(files, header_lines_count)
   end
 
+  -- put the cursor on the first line after the header
+  if header_lines_count > 0 then
+    vim.schedule(function()
+      vim.cmd("normal! " .. header_lines_count + 1 .. "G")
+    end)
+  end
+
   if #files == 0 then
     set_nocontent_text()
   end

--- a/lua/lir/config.lua
+++ b/lua/lir/config.lua
@@ -31,8 +31,10 @@ local config = {}
 ---@field float             lir.config.values.float
 ---@field hide_cursor       boolean
 ---@field get_filters fun(): lir.config.filter_func[]
+---@field header            string
+---@field disable_highlight boolean
+---@field show_navigation   boolean
 config.values = {}
-
 
 ---@class lir.config.values.devicons
 ---@field enable            boolean

--- a/lua/lir/context.lua
+++ b/lua/lir/context.lua
@@ -6,6 +6,7 @@
 ---@field dir   string
 ---@field files lir_item[]
 ---@field pasted_files lir_pasted_info[]
+---@field header_offset number
 local Context = {}
 
 ---@class lir_item
@@ -22,16 +23,17 @@ local Context = {}
 
 ---@param dir string
 ---@return lir_context
-function Context.new(dir)
+function Context.new(dir, header_offset)
   local self = setmetatable({}, { __index = Context })
   self.dir = dir
   self.files = nil
+  self.header_offset = header_offset or 0
   return self
 end
 
 ---@return lir_item|nil
 function Context:current()
-  local file = self.files[vim.fn.line(".")]
+  local file = self.files[vim.fn.line(".") - self.header_offset]
   if file then
     return file
   end
@@ -45,7 +47,8 @@ function Context:current_items(mode)
   if mode == "v" then
     s, e = vim.fn.line("'<"), vim.fn.line("'>")
   else
-    s, e = vim.fn.line("."), vim.fn.line(".")
+    local line = vim.fn.line(".") - self.header_offset
+    s, e = line, line
   end
 
   local results = {}
@@ -57,7 +60,7 @@ end
 
 ---@return string
 function Context:current_value()
-  local file = self.files[vim.fn.line(".")]
+  local file = self.files[vim.fn.line(".") - self.header_offset]
   if file then
     return file.value
   end
@@ -77,7 +80,7 @@ end
 
 ---@return boolean
 function Context:is_dir_current()
-  local file = self.files[vim.fn.line(".")]
+  local file = self.files[vim.fn.line(".") - self.header_offset]
   if file then
     return file.is_dir
   end

--- a/lua/lir/devicons.lua
+++ b/lua/lir/devicons.lua
@@ -52,12 +52,13 @@ function devicons.get_devicons(filename, is_dir)
 end
 
 ---@param files lir_item[]
-function devicons.update_highlight(files)
+---@param header_offset integer
+function devicons.update_highlight(files, header_offset)
   local col_start, col_end = #" ", ICON_WIDTH + #" "
 
   a.nvim_buf_clear_namespace(0, ns, 0, -1)
   for i, file in ipairs(files) do
-    a.nvim_buf_add_highlight(0, ns, file.devicons.highlight_name, i - 1, col_start, col_end)
+    a.nvim_buf_add_highlight(0, ns, file.devicons.highlight_name, i - 1 + header_offset, col_start, col_end)
   end
 end
 

--- a/lua/lir/highlight.lua
+++ b/lua/lir/highlight.lua
@@ -16,15 +16,16 @@ local ns = a.nvim_create_namespace("lir_dir")
 local highlight = {}
 
 ---@param files lir_item[]
-function highlight.update_highlight(files)
+---@param header_offset integer
+function highlight.update_highlight(files, header_offset)
   if config.values.devicons.enable then
-    devicons.update_highlight(files)
+    devicons.update_highlight(files, header_offset)
   end
   if not config.values.devicons.enable or config.values.devicons.highlight_dirname then
     a.nvim_buf_clear_namespace(0, ns, 0, -1)
     for i, file in ipairs(files) do
       if file.is_dir then
-        a.nvim_buf_add_highlight(0, ns, "LirDir", i - 1, 0, -1)
+        a.nvim_buf_add_highlight(0, ns, "LirDir", i - 1 + header_offset, 0, -1)
       end
     end
   end

--- a/plugin/lir.vim
+++ b/plugin/lir.vim
@@ -33,6 +33,7 @@ function Define_hlgroups()
   highlight def      LirTransparentCursor gui=strikethrough blend=100
   highlight def link LirFloatBorder             FloatBorder
   highlight def link LirFloatCursorLine         CursorLine
+  highlight def link LirHeader                  Comment
 endfunction
 
 call Define_hlgroups()


### PR DESCRIPTION
Hey!

This is a pull request with several changes:
- Add an option for a custom header string
- Add an option to disable highlights
- Add an option to show './' and '../' dirs (would solve https://github.com/tamago324/lir.nvim/issues/85)

Entries in the help file are included for the default/english version.

The changes are not perfect though.
- I wasn't able to properly set a highlight group for the custom header (see "FIXME: ..." tag in lir.lua)

Here is an example of what the options could be used for, a look a little similar to netrw:
![image](https://github.com/tamago324/lir.nvim/assets/64093588/a163a040-3ba0-4b86-8add-f1d3f9edb38b)