### PR TITLE
avoid accessing devicons config table if it's nil

### DIFF
--- a/lua/lir.lua
+++ b/lua/lir.lua
@@ -46,7 +46,7 @@ local function readdir(path)
 
     local prefix = config.values.hide_cursor and "" or " "
 
-    if config.values.devicons.enable then
+    if config.values.devicons and config.values.devicons.enable then
       local icon, highlight_name = devicons.get_devicons(name, is_dir)
       file.display = string.format("%s%s %s%s", prefix, icon, name, (is_dir and "/" or ""))
       file.devicons = { icon = icon, highlight_name = highlight_name }


### PR DESCRIPTION
in cases where devicons is left unconfigured or is configured improperly, the setup function throws an error when the if statement tries to access the enable property because the devicons property is nil